### PR TITLE
make rental type plural

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -11,7 +11,7 @@ export default function() {
   this.get('/rentals', function(db, request) {
     let rentals = [
       {
-        type: 'rental',
+        type: 'rentals',
         id: 1,
         attributes: {
           "title": "Grand Old Mansion",
@@ -23,7 +23,7 @@ export default function() {
         }
       },
       {
-        type: 'rental',
+        type: 'rentals',
         "id": 2,
         attributes: {
           "title": "Urban Living",
@@ -35,7 +35,7 @@ export default function() {
         }
       },
       {
-        type: 'rental',
+        type: 'rentals',
         "id": 3,
         attributes: {
           "title": "Downtown Charm",


### PR DESCRIPTION
type is plural in jsonapi samples and is the more standard way.  Updated both the guides and super rentals
