### PR TITLE
Remove unnecessary filter-listing component actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repo is currently *under development*.
 You will need the following things properly installed on your computer.
 
 * [Git](http://git-scm.com/)
-* [Node.js](http://nodejs.org/) (with NPM)
+* [Node.js](http://nodejs.org/) (with npm)
 * [Bower](http://bower.io/)
 * [Ember CLI](http://www.ember-cli.com/)
 * [PhantomJS](http://phantomjs.org/)
@@ -51,4 +51,3 @@ Specify what it takes to deploy your app.
 * Development Browser Extensions
   * [ember inspector for chrome](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi)
   * [ember inspector for firefox](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/)
-

--- a/app/components/filter-listing.js
+++ b/app/components/filter-listing.js
@@ -3,13 +3,8 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   filter: null,
   filteredList: null,
+
   actions: {
-    autoComplete() {
-      this.get('autoComplete')(this.get('filter'));
-    },
-    search() {
-      this.get('search')(this.get('filter'));
-    },
     choose(city) {
       this.set('filter', city);
     }

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   filteredList: null,
+
   actions: {
     autoComplete(param) {
       if (param !== '') {

--- a/app/templates/components/filter-listing.hbs
+++ b/app/templates/components/filter-listing.hbs
@@ -1,5 +1,6 @@
-City: {{input value=filter key-up=(action 'autoComplete')}}
-<button {{action 'search'}}>Search</button>
+City: {{input value=filter key-up=(action autoComplete filter)}}
+
+<button {{action search filter}}>Search</button>
 
 <ul>
   {{#each filteredList as |item|}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -2,7 +2,12 @@
 
 We hope you find exactly what you're looking for in a place to stay.
 <br/><br/>
-{{filter-listing filteredList=filteredList autoComplete=(action 'autoComplete') search=(action 'search')}}
+
+{{filter-listing
+  filteredList=filteredList
+  autoComplete=(action 'autoComplete')
+  search=(action 'search')}}
+
 <ul>
   {{#each model as |rentalUnit|}}
     {{rental-listing rental=rentalUnit}}


### PR DESCRIPTION
The `filter-listing` component has two actions -- `autoComplete` and `search` -- that should be removed.

Per @toddjordan's https://github.com/emberjs/guides/pull/1401#discussion_r60858081, the two actions could simply be passed down to the `filter-listing` component, from the `index` controller, without having an additional layer of component-actions.
