### PR TITLE
Add helper functions to index controller actions

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -3,19 +3,46 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   filteredList: null,
 
+  findAllRentals() {
+    return this.get('store').findAll('rental');
+  },
+
+  queryRentals(filter) {
+    return this.get('store').query('rental', { city: filter });
+  },
+
+  resetRentalModel() {
+    this.findAllRentals().then(result => {
+      this.set('model', result);
+    });
+  },
+
+  updateFilteredList(filter) {
+    this.queryRentals(filter).then(result => {
+      this.set('filteredList', result);
+    });
+  },
+
+  updateRentalModel(filter) {
+    this.queryRentals(filter).then(result => {
+      this.set('model', result);
+    });
+  },
+
   actions: {
-    autoComplete(param) {
-      if (param !== '') {
-        this.get('store').query('rental', { city: param }).then((result) => this.set('filteredList', result));
+    autoComplete(filter) {
+      if (filter && filter !== '') {
+        this.updateFilteredList(filter);
       } else {
         this.set('filteredList', null);
       }
     },
-    search(param) {
-      if (param !== '') {
-        this.store.query('rental', { city: param }).then((result) => this.set('model', result));
+
+    search(filter) {
+      if (filter && filter !== '') {
+        this.updateRentalModel(filter);
       } else {
-        this.get('store').findAll('rental').then((result) => this.set('model', result));
+        this.resetRentalModel();
       }
     }
   }


### PR DESCRIPTION
For a beginner, who may not be experienced with promises, I believe that having helper functions that perform exactly what their names indicate would provide a great deal of clarity. This, however, does add more lines and could be seen as unnecessary.

Additionally, since the `filter-listing` component uses the `filter` property, the controller actions that are passed the string should also refer to it as `filter`.

There should be a check for `filter !== null` before querying from the store.
