### PR TITLE
add api/ namespace for mirage requests

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.JSONAPIAdapter.extend({
+  namespace: 'api'
+});

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -8,6 +8,8 @@ export default function() {
     Note: these only affect routes defined *after* them!
   */
 
+  this.namespace = '/api';
+
   this.get('/rentals', function(db, request) {
     let rentals = [
       {
@@ -61,7 +63,6 @@ export default function() {
 
 
   // this.urlPrefix = '';    // make this `http://localhost:8080`, for example, if your API is on a different server
-  // this.namespace = '';    // make this `api`, for example, if your API is namespaced
   // this.timing = 400;      // delay for each request, automatically set to 0 during testing
 
   /*

--- a/tests/unit/adapters/application-test.js
+++ b/tests/unit/adapters/application-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:application', 'Unit | Adapter | application', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});


### PR DESCRIPTION
Per comment here: https://github.com/emberjs/guides/pull/1603#issuecomment-238373660

This updates the namespace for mirage/api requests to `api`.  We should now see requests going to `api/rentals` rather than hijacking the `rentals` path.

<img width="822" alt="screen shot 2016-08-08 at 8 40 34 pm" src="https://cloud.githubusercontent.com/assets/881981/17500959/76330c2a-5da8-11e6-995a-55a2d9019e46.png">
