### PR TITLE
[fix] mirage namespace for rentals

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -8,7 +8,7 @@ export default function() {
     Note: these only affect routes defined *after* them!
    */
 
-  this.namespace = '/api';
+  this.namespace = '/';
   let rentals = [
     {
       type: 'rentals',


### PR DESCRIPTION
In Building a Complex Component section of the tutorial, we change the mirage configuration and if the namespace is not root ('/'), we have a 404 on GET /rentals.