### PR TITLE
Add Heroku Button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Super-rentals
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 Super Rentals is the working repository of the Ember tutorial: https://guides.emberjs.com/v2.9.0/tutorial/ember-cli/
 
 ## Prerequisites

--- a/app.json
+++ b/app.json
@@ -1,0 +1,11 @@
+{
+  "name": "Super Rentals",
+  "description": "Super Rentals is the working repository of the Ember tutorial",
+  "repository": "https://github.com/ember-learn/super-rentals",
+  "keywords": ["ember", "ember.js"],
+  "buildpacks": [
+    {
+      "url": "https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz"
+    }
+  ]
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -43,7 +43,11 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-
+    // use mirage in production too since the app will break
+    // if there is no API for Ember Data
+    ENV['ember-cli-mirage'] = {
+      enabled: true
+    }
   }
 
   return ENV;


### PR DESCRIPTION
This adds a [Heroku Button](https://devcenter.heroku.com/articles/heroku-button) to the README for easy 1-click deploys. In addition, it also lets mirage to be used in production ember builds or else it will break during a production build.