### PR TITLE
Google API Key

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,5 +7,10 @@
     {
       "url": "https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz"
     }
-  ]
+  ],
+  "env": {
+    "GOOGLE_API_KEY": {
+      "description": "Google API KEY for Google Maps, https://developers.google.com/maps/documentation/javascript/get-api-key"
+    }
+  }
 }

--- a/app/index.html
+++ b/app/index.html
@@ -19,7 +19,6 @@
 
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/super-rentals.js"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?v=3.22"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+import config from 'super-rentals/config/environment';
+import injectScript from 'super-rentals/utils/inject-script';
+
+export default Ember.Route.extend({
+  model() {
+    let src = `https://maps.googleapis.com/maps/api/js?v=3.22&key=${config.googleApiKey}`;
+    return injectScript(src);
+  }
+});

--- a/app/utils/inject-script.js
+++ b/app/utils/inject-script.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+export default function injectScript(src) {
+  return new Ember.RSVP.Promise(function(resolve) {
+    var script    = document.createElement('script');
+    script.type   = 'text/javascript';
+    script.async  = true;
+    script.src    = src;
+    script.onload = Ember.run.bind(null, resolve);
+    document.getElementsByTagName('head')[0].appendChild(script);
+  });
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -6,6 +6,7 @@ module.exports = function(environment) {
     environment: environment,
     rootURL: '/',
     locationType: 'auto',
+    googleApiKey: process.env.GOOGLE_API_KEY || '',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build


### PR DESCRIPTION
Allow people to specify the Google API Key during `ember build` that's now required for viewing the maps.