### PR TITLE
use addon instead of direct maps script reference

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,5 +7,10 @@
     {
       "url": "https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz"
     }
-  ]
+  ],
+  "env": {
+    "GOOGLE_MAPS_API_KEY": {
+      "description": "Google API KEY for Google Maps, https://developers.google.com/maps/documentation/javascript/get-api-key"
+    }
+  }
 }

--- a/app/index.html
+++ b/app/index.html
@@ -19,7 +19,6 @@
 
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/super-rentals.js"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?v=3.22"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^4.0.0",
+    "ember-simple-google-maps": "^1.0.0",
     "ember-source": "~2.13.0",
     "loader.js": "^4.2.3"
   },


### PR DESCRIPTION
[ember-simple-google-maps](https://github.com/ember-learn/ember-simple-google-maps) provides the maps script reference via "content for", and allows an API key to be provided via environment variable