### PR TITLE
Change block parameter to clarify connection to yield (#81)

### DIFF
--- a/app/templates/rentals/index.hbs
+++ b/app/templates/rentals/index.hbs
@@ -1,8 +1,8 @@
 {{#list-filter
    filter=(action 'filterByCity')
-   as |rentals|}}
+   as |filteredResults|}}
   <ul class="results">
-    {{#each rentals as |rentalUnit|}}
+    {{#each filteredResults as |rentalUnit|}}
       <li>{{rental-listing rental=rentalUnit}}</li>
     {{/each}}
   </ul>


### PR DESCRIPTION
This will align super-rentals to changes made in the guides.
|rentals| is changed to |filterResults| to make its connection
to {{yield results}} more explicit.

See: https://github.com/emberjs/guides/issues/2092