### PR TITLE
Corrected ''should display 1 listing' assertion

### DIFF
--- a/tests/acceptance/list-rentals-test.js
+++ b/tests/acceptance/list-rentals-test.js
@@ -51,7 +51,7 @@ module('Acceptance | list rentals', function(hooks) {
     await visit('/');
     await fillIn('.list-filter input', 'seattle');
     await triggerKeyEvent('.list-filter input', 'keyup', 69);
-    assert.ok(this.element.querySelector('.results .listing'), 'should display 1 listing');
+      assert.ok(this.element.querySelectorAll('.results .listing').length, 1, 'should display 1 listing');
     assert.ok(this.element.querySelector('.listing .location').textContent.includes('Seattle'), 'should contain 1 listing with location Seattle');
   });
 


### PR DESCRIPTION
Changed the first assertion in the 'should filter the list of rentals by city' test to check for a single listing. There's not an open issue for this on the ember-learn/super-rentals, but it's requested by @jenweber  in the comments of this pull request in the tutorials repo: 
https://github.com/emberjs/guides/pull/2283