### PR TITLE
…

### DIFF
--- a/app/services/maps.js
+++ b/app/services/maps.js
@@ -5,6 +5,7 @@ import MapUtil from '../utils/google-maps';
 
 export default Service.extend({
   init() {
+    this._super(...arguments);
     if (!this.get('cachedMaps')) {
       this.set('cachedMaps', EmberObject.create());
     }


### PR DESCRIPTION
Added this._super(...arguments); to init() to follow best practices and to pass ESLint test.
This fails the ESLint test 9:3 - Call this._super(...arguments) in init hook (ember/require-super-in-init)
Updated the guide to match with this PR https://github.com/emberjs/guides/pull/2321