### PR TITLE
list-filter-test: Adjust test module name.

### DIFF
--- a/tests/integration/components/list-filter-test.js
+++ b/tests/integration/components/list-filter-test.js
@@ -4,7 +4,7 @@ import { render, settled, triggerKeyEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { resolve } from 'rsvp';
 
-module('Integration | Component | list filter', function(hooks) {
+module('Integration | Component | list-filter', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {


### PR DESCRIPTION
A generated test file uses 'list-filter' instead of 'list filter',
so correct it here to be consistent with what the end user would
generate.

See https://github.com/ember-learn/guides-source/pull/189
