### PR TITLE
Update use of `settled` helper in integration tests.

### DIFF
--- a/tests/integration/components/list-filter-test.js
+++ b/tests/integration/components/list-filter-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, triggerKeyEvent } from '@ember/test-helpers';
+import { render, settled, triggerKeyEvent, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { resolve } from 'rsvp';
 
@@ -61,7 +61,7 @@ module('Integration | Component | list-filter', function(hooks) {
       </ListFilter>
     `);
 
-
+    await fillIn(this.element.querySelector('.list-filter input'),'s');
     await triggerKeyEvent(this.element.querySelector('.list-filter input'), "keyup", 83);
     await settled();
 

--- a/tests/integration/components/list-filter-test.js
+++ b/tests/integration/components/list-filter-test.js
@@ -31,10 +31,10 @@ module('Integration | Component | list-filter', function(hooks) {
       </ListFilter>
     `);
 
-    return settled().then(() => {
-      assert.equal(this.element.querySelectorAll('.city').length, 3);
-      assert.dom(this.element.querySelector('.city')).hasText('San Francisco');
-    });
+    await settled();
+
+    assert.equal(this.element.querySelectorAll('.city').length, 3);
+    assert.dom(this.element.querySelector('.city')).hasText('San Francisco');
   });
 
   test('should update with matching listings', async function(assert) {
@@ -63,10 +63,9 @@ module('Integration | Component | list-filter', function(hooks) {
 
 
     await triggerKeyEvent(this.element.querySelector('.list-filter input'), "keyup", 83);
+    await settled();
 
-    return settled().then(() => {
-      assert.ok(this.element.querySelector('.city'), 'one result found');
-      assert.dom(this.element.querySelector('.city')).hasText('San Francisco');
-    });
+    assert.equal(this.element.querySelectorAll('.city').length, 1, 'One result returned');
+    assert.dom(this.element.querySelector('.city')).hasText('San Francisco');
   });
 });


### PR DESCRIPTION
Make use of async / await when using the `settled` helper to be consistent with the implementation other asynchronous test helpers. Change made to reflect changes made in [guides-source PR](https://github.com/ember-learn/guides-source/pull/390) at the suggestion of @jenweber 