### PR TITLE
bugfix - headless chrome crashed in tests

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -13,7 +13,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',


### PR DESCRIPTION
See https://github.com/ember-cli/ember-cli/pull/8774

This PR fixes an issue where some people may try to run the app and fail because the browser crashes on headless chrome tests. This was due to a breaking change in Chrome.