### PR TITLE
Deprecate Store class extention

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,11 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
     // Add options here
+    emberData: {
+      deprecations: {
+        DEPRECATE_STORE_EXTENDS_EMBER_OBJECT: false
+      }
+    }
   });
 
   return app.toTree();


### PR DESCRIPTION
The Super Rentals App is not visible as Firefox (136.0.02 mint-001 1.0) and the JS console suggests to mark the Store class as no longer extending from EmberObject.
```
To mark the class as no longer extending from EmberObject, in ember-cli-build.js
set the following config...
```
After this, the Super Rentals App is visible again.